### PR TITLE
remove Beta designations

### DIFF
--- a/vsi_best_practices.md
+++ b/vsi_best_practices.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2018
-lastupdated: "2018-06-01"
+lastupdated: "2018-09-10"
 
 ---
 

--- a/vsi_best_practices.md
+++ b/vsi_best_practices.md
@@ -19,7 +19,7 @@ lastupdated: "2018-06-01"
 When you are planning to provision {{site.data.keyword.BluVirtServers}} instances, you might find this configuration checklist helpful to get the most out of your virtual server deployment.
 {:shortdesc}
 
-Currently, in the IBM Cloud Virtual Private Cloud (VPC) beta, you cannot create an instance before you create a VPC.  If you do not have a virtual private cloud created, see [Getting started with IBM Cloud Virtual Private Cloud (VPC)](/docs/infrastructure/vpc/getting-started.html) first. This limitation will be removed soon!
+Currently, in the IBM Cloud Virtual Private Cloud (VPC) beta, you cannot create an instance before you create a VPC.  If you do not have a virtual private cloud created, see [Getting started with IBM Cloud Virtual Private Cloud (VPC)](/docs/infrastructure/vpc/getting-started.html) first.
 {:tip}
 
 After you have a VPC available, consider the following before you provision your instance.
@@ -35,7 +35,7 @@ After you have a VPC available, consider the following before you provision your
 |__ 7. What are the port speeds you need? You have two port speed options: 100 Mbps, or 1000 Mbps. This option cannot be modified after you create the instance.  Choose a network interface with the speed that best balances cost versus performance for your design. |
 |__ 8. Have you selected a unique name for the instance? If you have a method to naming virtual server instances, it is much easier to filter and search on them later. |
 
-**We'd like your input!** Beta users, when it comes to compute resources, we often hear requests for better tips on capacity considerations, account limitations, or permissions... what other tips or best practice areas are you curious about? what do you think would help?  We would love to hear from you.  Please click **Edit in Github** on this page to open a pull request or create an issue with your thoughts and ideas.  Thank you!
+**We'd like your input!** When it comes to compute resources, we often hear requests for better tips on capacity considerations, account limitations, or permissions... what other tips or best practice areas are you curious about? what do you think would help?  We would love to hear from you. Please click **Edit in Github** on this page to open a pull request or create an issue with your thoughts and ideas. Thank you!
 
 ## What's next?
 When you're ready to get started, see the following resources to create your instance:

--- a/vsi_best_practices.md
+++ b/vsi_best_practices.md
@@ -19,7 +19,7 @@ lastupdated: "2018-06-01"
 When you are planning to provision {{site.data.keyword.BluVirtServers}} instances, you might find this configuration checklist helpful to get the most out of your virtual server deployment.
 {:shortdesc}
 
-Currently, in the IBM Cloud Virtual Private Cloud (VPC) beta, you cannot create an instance before you create a VPC.  If you do not have a virtual private cloud created, see [Getting started with IBM Cloud Virtual Private Cloud (VPC)](/docs/infrastructure/vpc/getting-started.html) first.
+Currently, in the IBM Cloud Virtual Private Cloud (VPC), you cannot create an instance before you create a VPC.  If you do not have a virtual private cloud created, see [Getting started with IBM Cloud Virtual Private Cloud (VPC)](/docs/infrastructure/vpc/getting-started.html) first.
 {:tip}
 
 After you have a VPC available, consider the following before you provision your instance.


### PR DESCRIPTION
also the need to create a VPC before creating instances will remain for at least the rest of this year, probably longer, so removed that sentence